### PR TITLE
disable vox for the time being

### DIFF
--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Vox
   name: species-name-vox
-  roundStart: true
+  roundStart: false
   prototype: MobVox
   sprites: MobVoxSprites
   markingLimits: MobVoxMarkingLimits


### PR DESCRIPTION
it's basically an unplayable option right now, since there are no options to get N2 tanks reliably.

gas filters would be a good thing to look into