### PR TITLE
Added the ability to refuel torches (and other expendable lights)

### DIFF
--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -1,10 +1,14 @@
 using Content.Server.Light.Components;
+using Content.Server.Stack;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.IgnitionSource;
+using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Content.Shared.Light.Components;
+using Content.Shared.NameModifier.EntitySystems;
+using Content.Shared.Stacks;
 using Content.Shared.Tag;
 using Content.Shared.Verbs;
 using JetBrains.Annotations;
@@ -22,7 +26,8 @@ namespace Content.Server.Light.EntitySystems
         [Dependency] private readonly TagSystem _tagSystem = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
-        [Dependency] private readonly MetaDataSystem _metaData = default!;
+        [Dependency] private readonly StackSystem _stackSystem = default!;
+        [Dependency] private readonly NameModifierSystem _nameModifier = default!;
 
         public override void Initialize()
         {
@@ -31,6 +36,8 @@ namespace Content.Server.Light.EntitySystems
             SubscribeLocalEvent<ExpendableLightComponent, ComponentInit>(OnExpLightInit);
             SubscribeLocalEvent<ExpendableLightComponent, UseInHandEvent>(OnExpLightUse);
             SubscribeLocalEvent<ExpendableLightComponent, GetVerbsEvent<ActivationVerb>>(AddIgniteVerb);
+            SubscribeLocalEvent<ExpendableLightComponent, InteractUsingEvent>(OnInteractUsing);
+            SubscribeLocalEvent<ExpendableLightComponent, RefreshNameModifiersEvent>(OnRefreshNameModifiers);
         }
 
         public override void Update(float frameTime)
@@ -65,9 +72,9 @@ namespace Content.Server.Light.EntitySystems
                     default:
                     case ExpendableLightState.Fading:
                         component.CurrentState = ExpendableLightState.Dead;
-                        var meta = MetaData(ent);
-                        _metaData.SetEntityName(ent, Loc.GetString(component.SpentName), meta);
-                        _metaData.SetEntityDescription(ent, Loc.GetString(component.SpentDesc), meta);
+                        _nameModifier.RefreshNameModifiers(ent.Owner);
+
+                        _tagSystem.AddTag(ent, "Trash");
 
                         _tagSystem.AddTag(ent, "Trash");
 
@@ -101,15 +108,46 @@ namespace Content.Server.Light.EntitySystems
                 RaiseLocalEvent(ent, ref ignite);
 
                 component.CurrentState = ExpendableLightState.Lit;
-                component.StateExpiryTime = component.GlowDuration;
 
                 UpdateSounds(ent);
                 UpdateVisualizer(ent);
+            }
+            return true;
+        }
 
-                return true;
+        private void OnInteractUsing(EntityUid uid, ExpendableLightComponent component, InteractUsingEvent args)
+        {
+            if (args.Handled)
+                return;
+
+            if (!EntityManager.TryGetComponent(args.Used, out StackComponent? stack))
+                return;
+
+            if (stack.StackTypeId != component.RefuelMaterialID)
+                return;
+
+            if (component.StateExpiryTime + component.RefuelMaterialTime >= component.RefuelMaximum)
+                return;
+
+            if (component.CurrentState is ExpendableLightState.Dead)
+            {
+                component.CurrentState = ExpendableLightState.BrandNew;
+                component.StateExpiryTime = component.RefuelMaterialTime;
+
+                _nameModifier.RefreshNameModifiers(uid);
+                _stackSystem.SetCount(args.Used, stack.Count - 1, stack);
+                UpdateVisualizer((uid, component));
+                return;
             }
 
-            return false;
+            component.StateExpiryTime += component.RefuelMaterialTime;
+            _stackSystem.SetCount(args.Used, stack.Count - 1, stack);
+        }
+
+        private void OnRefreshNameModifiers(EntityUid uid, ExpendableLightComponent component, RefreshNameModifiersEvent args)
+        {
+            if (component.CurrentState is ExpendableLightState.Dead)
+                args.AddModifier(component.SpentName);
         }
 
         private void UpdateVisualizer(Entity<ExpendableLightComponent> ent, AppearanceComponent? appearance = null)
@@ -168,6 +206,7 @@ namespace Content.Server.Light.EntitySystems
             }
 
             component.CurrentState = ExpendableLightState.BrandNew;
+            component.StateExpiryTime = component.GlowDuration;
             EntityManager.EnsureComponent<PointLightComponent>(uid);
         }
 

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -115,7 +115,7 @@ namespace Content.Server.Light.EntitySystems
             return true;
         }
 
-        private void OnInteractUsing(EntityUid uid, ExpendableLightComponent component, InteractUsingEvent args)
+        private void OnInteractUsing(EntityUid uid, ExpendableLightComponent component, ref InteractUsingEvent args)
         {
             if (args.Handled)
                 return;
@@ -142,6 +142,7 @@ namespace Content.Server.Light.EntitySystems
 
             component.StateExpiryTime += component.RefuelMaterialTime;
             _stackSystem.SetCount(args.Used, stack.Count - 1, stack);
+            args.Handled = true;
         }
 
         private void OnRefreshNameModifiers(EntityUid uid, ExpendableLightComponent component, RefreshNameModifiersEvent args)

--- a/Content.Shared/Light/Components/SharedExpendableLightComponent.cs
+++ b/Content.Shared/Light/Components/SharedExpendableLightComponent.cs
@@ -23,11 +23,17 @@ public abstract partial class SharedExpendableLightComponent : Component
     [DataField("fadeOutDuration")]
     public float FadeOutDuration { get; set; } = 60 * 5f;
 
-    [DataField("spentDesc")]
-    public string SpentDesc { get; set; } = string.Empty;
-
     [DataField("spentName")]
     public string SpentName { get; set; } = string.Empty;
+
+    [DataField("refuelMaterialID")]
+    public string? RefuelMaterialID { get; set; } = null;
+
+    [DataField("refuelMaterialTime")]
+    public float RefuelMaterialTime { get; set; } = 15f;
+
+    [DataField("refuelMaximum")]
+    public float RefuelMaximum { get; set; } = 60 * 15f * 2;
 
     [DataField("litSound")]
     public SoundSpecifier? LitSound { get; set; }

--- a/Resources/Prototypes/Entities/Objects/Misc/torch.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/torch.yml
@@ -6,7 +6,8 @@
   components:
     - type: ExpendableLight
       spentName: expendable-light-burnt-torch-name
-      spentDesc: expendable-light-burnt-torch-desc
+      refuelMaterialID: WoodPlank
+      refuelMaximum: 205
       glowDuration: 100
       fadeOutDuration: 4
       iconStateSpent: torch_spent
@@ -79,3 +80,5 @@
     - type: Tag
       tags:
       - Torch
+    - type: NameModifier
+      baseName: torch


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR adds the ability to refuel entities with the ExpendableLights component.

## Why / Balance
Previously, torches could not be refueled and left wasted items, making a survival experience terrible. This patch fixes the issue by adding the ability to refuel 

## Technical details
This patch makes two revamps, namely:
* Adds extra parameters to allow refueling 
* Changes the ExpendableLightSystem to change names using the NameModifierSystem

## Media
https://files.catbox.moe/oatj4r.mov

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Torches can now be refueled.
- fix: Burnt torches/glowsticks names' can now display if they're glued, cluwnified, etc.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
