### PR TITLE
Research Rebalance

### DIFF
--- a/Resources/Prototypes/_tc14/Entities/Structures/Machines/workbench.yml
+++ b/Resources/Prototypes/_tc14/Entities/Structures/Machines/workbench.yml
@@ -30,12 +30,9 @@
     - CablesStatic
     - CargoStatic
     - MaterialsStatic
-    - BasicChemistryStatic
     - RollerBedsStatic
     - LightsStatic
     - ServiceStatic
-    - PowerCellsStatic
-    - ElectronicsWorkbench
   - type: BlueprintReceiver
     whitelist:
       tags:

--- a/Resources/Prototypes/_tc14/research_projects.yml
+++ b/Resources/Prototypes/_tc14/research_projects.yml
@@ -93,3 +93,65 @@
   - HotplateMachineCircuitboard
   - ChemDispenserMachineCircuitboard
   - ChemMasterMachineCircuitboard
+
+- type: bluebenchResearch
+  id: CommonElectricityResearch
+  name: Electricity
+  description: This is where the fun begins.
+  icon:
+    sprite: Structures/Power/smes.rsi
+    state: smes
+  stackRequirements:
+    Steel: 15
+    Glass: 15
+    Plastic: 15
+  outputRecipes:
+  - DoorElectronics
+  - SignalTimerElectronics
+  - APCElectronics
+  - SMESMachineCircuitboard
+  - SubstationMachineCircuitboard
+  - WallmountSubstationElectronics
+  - CellRechargerCircuitboard
+  - WeaponCapacitorRechargerCircuitboard
+  - PortableGeneratorCPacmanMachineCircuitboard
+  - PowerCellSmall
+  - PowerCellMedium
+
+- type: bluebenchResearch
+  id: CommonFabricationResearch
+  name: Fabrication
+  description: Advanced means of constructing items.
+  requiredResearch: CommonElectricityResearch
+  icon:
+    sprite: Structures/Machines/protolathe.rsi
+    state: icon
+  stackRequirements:
+    Steel: 10
+    Glass: 5
+    Plastic: 10
+    Capacitor: 3
+    Cable: 10
+  outputRecipes:
+  - ProtolatheMachineCircuitboard
+  - AutolatheMachineCircuitboard
+  - CircuitImprinterMachineCircuitboard
+  - ExosuitFabricatorMachineCircuitboard
+  - CutterMachineCircuitboard
+  - BorgChargerCircuitboard
+
+- type: bluebenchResearch
+  id: CommonRNDResearch
+  name: R&D
+  description: Science just exploded. Again.
+  requiredResearch: CommonElectricityResearch
+  icon:
+    sprite: Objects/Specific/Xenoarchaeology/xeno_artifacts.rsi
+    state: ano13
+  stackRequirements:
+    ArtifactFragment: 16
+  outputRecipes:
+  - NodeScanner
+  - TechDiskComputerCircuitboard
+  - AnalysisComputerCircuitboard
+  - ArtifactAnalyzerMachineCircuitboard

--- a/Resources/Prototypes/_tc14/research_projects.yml
+++ b/Resources/Prototypes/_tc14/research_projects.yml
@@ -5,16 +5,19 @@
   icon:
     sprite: Objects/Specific/Medical/medical.rsi
     state: brutepack
-  tagRequirements:
-    GlassBeaker:
-      amount: 2
-      defaultPrototype: Beaker
   stackRequirements:
     Steel: 5
+    Glass: 10
   outputRecipes:
     - Brutepack
     - Ointment
     - Gauze
+    - Scalpel
+    - Retractor
+    - Cautery
+    - Drill
+    - Saw
+    - Hemostat
 
 - type: bluebenchResearch
   id: BasicSecurityResearch
@@ -29,15 +32,64 @@
       defaultPrototype: ArrowImprovisedRock
   stackRequirements:
     Cable: 5
-    Steel: 5
   outputRecipes:
   - Handcuffs
   - TargetClown
   - TargetHuman
   - TargetSyndicate
   - Zipties
+  - CombatKnife
+
+- type: bluebenchResearch
+  id: CommonSecurityResearch
+  name: Non-Lethal Weaponry
+  description: Pick up that can.
+  requiredResearch: BasicSecurityResearch
+  icon:
+    sprite: Objects/Weapons/Melee/stunbaton.rsi
+    state: stunbaton_off
+  stackRequirements:
+    Capacitor: 3
+    Steel: 10
+    Plastic: 5 # :godo:
+  outputRecipes:
   - Flash
   - Stunbaton
-  - CombatKnife
   - RiotShield
   - WeaponDisabler
+
+- type: bluebenchResearch
+  id: BasicChemistryResearch
+  name: Home Chemistry
+  description: Also known as Tiderchem in underground circles.
+  icon:
+    sprite: Objects/Specific/Chemistry/beaker.rsi
+    state: beaker
+  stackRequirements:
+    Glass: 10
+    MaterialWoodPlank: 5
+  outputRecipes:
+  - Beaker
+  - LargeBeaker
+  - Syringe
+  - PillCanister
+  - Jug
+  - ChemistryEmptyBottle01
+
+- type: bluebenchResearch
+  id: CommonChemistryResearch
+  name: Advanced Chemistry Tools
+  description: Having these items separates amateurs from pros.
+  requiredResearch: BasicChemistryResearch
+  icon:
+    sprite: Clothing/Eyes/Glasses/science.rsi
+    state: icon
+  stackRequirements:
+    Glass: 15
+    Plastic: 15
+  # add some liquid requirement
+  outputRecipes:
+  - ClothingEyesGlassesChemical
+  - HotplateMachineCircuitboard
+  - ChemDispenserMachineCircuitboard
+  - ChemMasterMachineCircuitboard

--- a/Resources/Prototypes/_tc14/research_projects.yml
+++ b/Resources/Prototypes/_tc14/research_projects.yml
@@ -67,7 +67,7 @@
     state: beaker
   stackRequirements:
     Glass: 10
-    MaterialWoodPlank: 5
+    WoodPlank: 5
   outputRecipes:
   - Beaker
   - LargeBeaker


### PR DESCRIPTION
Basic Medicine now needs glass instead of beakers, also grants you with surgery tools
Cuff'n'Dagger no longer needs steel, but does not grant flashes, shield and disabler - Non-Lethal Weaponry grants those instead.
2 new chemistry-related researches have been added - the first does not need plastic, meaning that you should be able to get to the plastic via chem reaction relatively easily.
TODO:
Electricity research, granting APC electronics, CPACMAN, cables and other stuff
Lathes research, granting auto/protolathes and circuit imprinter
Basic R&D granting research servers, artifact research stuff and (potentially) destructive analyzer-like machine