### PR TITLE
[hotfix] Add a fixture to bushes

### DIFF
--- a/Resources/Prototypes/_tc14/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/_tc14/Entities/Objects/Decoration/flora.yml
@@ -12,7 +12,16 @@
     drawdepth: Overdoors
   - type: Physics
     bodyType: Static
-    canCollide: false
+    # canCollide: false
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.05,-0.05,0.05,0.05"
+        density: 1000
+        layer:
+        - WallLayer
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Web # do not ask


### PR DESCRIPTION
## About the PR
Added a fixture to bushes so you can at least hit them with a wideswing.
This is a dirty fix, still, but I am planning to make bushes into a decoration/cover instead of source of items, so it'll do.

## Why / Balance
bug

## Technical details

## Media

## Requirements

## Breaking changes

**Changelog**
:cl:
- fix: You can now actually hit bushes.
