### PR TITLE
[cleanup] General blueprint workbench improvements

### DIFF
--- a/Content.Client/Blueprint/UI/BluebenchMenu.xaml.cs
+++ b/Content.Client/Blueprint/UI/BluebenchMenu.xaml.cs
@@ -80,7 +80,7 @@ public sealed partial class BluebenchMenu : DefaultWindow
 
     public void UpdateRequiredComponents()
     {
-        ActiveResearch.Text = _loc.GetString("bluebench-active-project") +
+        ActiveResearch.Text = _loc.GetString("bluebench-active-project") + " " +
                               (ActiveResearchProto == null ? "N/A" : ActiveResearchProto.Name);
         if (ActiveResearchProto is null)
             return;
@@ -100,7 +100,7 @@ public sealed partial class BluebenchMenu : DefaultWindow
             if (stackPrototype.Icon is not null)
                 _spriteSystem.GetFrame(stackPrototype.Icon, TimeSpan.Zero, false);
 
-            Requirements.AddChild(new BluebenchMaterialRequirement(frame, $"{value}x {stackPrototype.Name}"));
+            Requirements.AddChild(new BluebenchMaterialRequirement(frame, $"{value}x {Loc.GetString(stackPrototype.Name)}"));
         }
 
         foreach (var (key, value) in TagProgress)
@@ -111,7 +111,7 @@ public sealed partial class BluebenchMenu : DefaultWindow
             if (!prototypeManager.TryIndex(key, out var tagPrototype))
                 continue;
 
-            Requirements.AddChild(new BluebenchMaterialRequirement(null, $"{value}x {tagPrototype.ID}"));
+            Requirements.AddChild(new BluebenchMaterialRequirement(null, $"{value}x {tagPrototype.ID.ToLower()}"));
         }
 
         foreach (var (key, value) in ComponentProgress)
@@ -133,19 +133,21 @@ public sealed partial class BluebenchMenu : DefaultWindow
         foreach (var (key, value) in entry.StackRequirements)
         {
             message.PushNewline();
-            message.AddMarkupOrThrow($"{value}x {key.Id}");
+            if (_prototypeManager.Resolve(key, out var prototype))
+                message.AddMarkupOrThrow($"{value}x {Loc.GetString(prototype.Name)}");
         }
 
         foreach (var (key, value) in entry.TagRequirements)
         {
             message.PushNewline();
-            message.AddMarkupOrThrow($"{value.Amount}x {key.Id}");
+            message.AddMarkupOrThrow($"{value.Amount}x {key.Id.ToLower()}"); // ToLower for consistency with regular prototype names
         }
 
         foreach (var (key, value) in entry.ComponentRequirements)
         {
             message.PushNewline();
-            message.AddMarkupOrThrow($"{value.Amount}x {key}");
+            if (_prototypeManager.Resolve(key, out var prototype))
+                message.AddMarkupOrThrow($"{value.Amount}x {prototype.Name}");
         }
 
         return message;

--- a/Content.Shared/Research/Systems/BlueprintSystem.cs
+++ b/Content.Shared/Research/Systems/BlueprintSystem.cs
@@ -45,10 +45,10 @@ public sealed class BlueprintSystem : EntitySystem
 
             foreach (var recipe in recipes)
             {
-                if (!_prototypeManager.TryIndex(recipe, out var proto))
+                if (!_prototypeManager.Resolve(recipe, out var recipePrototype) || !_prototypeManager.Resolve(recipePrototype.Result, out var prototype))
                     continue;
 
-                formatted.AddText(proto.ID);
+                formatted.AddText(Loc.GetString(prototype.Name));
                 formatted.PushNewline();
             }
 

--- a/Resources/Locale/en-US/_tc14/bluebench.ftl
+++ b/Resources/Locale/en-US/_tc14/bluebench.ftl
@@ -4,8 +4,8 @@ blueprint-contains = This blueprint contains the following recipes:
 bluebench-available-tab = Available Research
 bluebench-completed-tab = Completed Research
 bluebench-blueprints-text = {$blueprintCount ->
-    [one] one blueprint inserted
-    *[other] {$blueprintCount} blueprints inserted
+    [one] one blueprint paper inserted
+    *[other] {$blueprintCount} blueprint paper inserted
 }
 bluebench-btn-start = Start
 bluebench-btn-print = Print


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## What was changed in this PR? What goals are you trying to achieve with these changes?
- Almost all instances of showing prototype IDs to the end user (VERY BAD) has been replaced with localized strings.
- Specified that you need blueprint paper, not blueprints.
- Same for blueprint examine.
Note: item icons are still borked.
## Please provide technical details to the implementation of this feature, if it's complex enough.

## Please attach the media showcasing the feature.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have read and am following the [TC14 Conventions](https://wiki.tc14.space/Conventions)

**Changelog**
:cl:
- fix: Blueprint-related text is now way clearer.
